### PR TITLE
Re-enable status bar

### DIFF
--- a/skiffWindowsApp/Skiff Desktop/MainWindow.xaml.cs
+++ b/skiffWindowsApp/Skiff Desktop/MainWindow.xaml.cs
@@ -148,7 +148,7 @@ namespace Skiff_Desktop
             WebView2.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = false;
             WebView2.CoreWebView2.Settings.IsPasswordAutosaveEnabled = true;
             WebView2.CoreWebView2.Settings.IsGeneralAutofillEnabled = true;
-            WebView2.CoreWebView2.Settings.IsStatusBarEnabled = false;
+            WebView2.CoreWebView2.Settings.IsStatusBarEnabled = true;
 
             // this is needed to allow the webview to communicate with the app
             // right now, only for sending notifications


### PR DESCRIPTION
Fixes: #10 

Re-enables the WebView2 status bar. This isn't a reliable/secure indicator of what lies behind a link, but is something at least. This change should be followed up with a warning dialog that shows the target location.

See also: https://www.chromium.org/user-experience/status-bubble/#lack-of-security