### PR TITLE
Changed to opening from tray with a single left click

### DIFF
--- a/skiffWindowsApp/Skiff Desktop/TrayController.cs
+++ b/skiffWindowsApp/Skiff Desktop/TrayController.cs
@@ -96,7 +96,7 @@ namespace Skiff_Desktop
                 },
                 Visible = true,
             };
-            _trayIcon.DoubleClick += OpenFromTray;
+            _trayIcon.MouseClick += OnMouseClick;
         }
 
         private void OnLaunchOnStartupPreferenceChange(object? sender, EventArgs e)
@@ -209,8 +209,14 @@ namespace Skiff_Desktop
             _preferencesController.SetCloseToTray(_closeToTrayPreferenceMenuItem.Checked);
         }
 
-        private void OpenFromTray(object? sender, EventArgs e)
+        private void OnMouseClick(object? sender, MouseEventArgs e)
         {
+            if (e.Button == MouseButtons.Left)
+                OpenFromTray(sender, e);
+        }
+
+        private void OpenFromTray(object? sender, EventArgs e)
+        { 
             if (_mainWindow.WindowState == WindowState.Minimized)
             {
                 _mainWindow.Show();


### PR DESCRIPTION
In relation to https://github.com/skiff-org/skiff-windows-app/issues/14 I've sligtly modified tray icon behaviour to open the Skiff Desktop window with a single left mouse button click.